### PR TITLE
fix: increase default timeout duration

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -72,6 +72,7 @@ pub struct Token {
 
 #[cfg(test)]
 pub(crate) mod test {
+    use chrono::{Duration, Utc};
     use rand::{distributions::Alphanumeric, Rng};
 
     use super::*;
@@ -84,12 +85,18 @@ pub(crate) mod test {
             .map(char::from)
             .collect::<String>();
 
+        let expiration_date = Utc::now()
+            .checked_add_signed(Duration::days(5))
+            .unwrap()
+            .naive_utc()
+            .date();
+
         let params = TokensParameters::new(
             "fossy",
             "fossy",
             &token_name,
             TokenScope::Write,
-            NaiveDate::from_ymd(2021, 10, 30),
+            expiration_date,
         );
 
         let token = tokens(&fossology, &params).unwrap();
@@ -116,7 +123,11 @@ pub(crate) mod test {
             "fossy",
             &token_name,
             TokenScope::Read,
-            NaiveDate::from_ymd(2021, 10, 30),
+            Utc::now()
+                .checked_add_signed(Duration::days(5))
+                .unwrap()
+                .naive_utc()
+                .date(),
         );
 
         let token = tokens(&fossology, &params).unwrap();
@@ -139,7 +150,11 @@ pub(crate) mod test {
             "fossy",
             &token_name,
             TokenScope::Write,
-            NaiveDate::from_ymd(2021, 10, 30),
+            Utc::now()
+                .checked_add_signed(Duration::days(5))
+                .unwrap()
+                .naive_utc()
+                .date(),
         );
 
         let tokens = tokens(&fossology, &params).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 use log::error;
 use reqwest::blocking::{Client, RequestBuilder};
 use serde::Deserialize;
+use std::time::Duration;
 use version_compare::{CompOp, VersionCompare};
 
 use crate::info::{ApiInformation, ApiInformationV1};
@@ -112,10 +113,13 @@ impl Fossology {
     /// - API version can't be retrieved.
     pub fn new(uri: &str, token: &str) -> Result<Self, FossologyError> {
         let version = Self::version(uri, token)?;
+        let client = Client::builder()
+            .timeout(Duration::from_secs(600))
+            .build()?;
         let fossology = Self {
             uri: uri.to_owned(),
             token: token.to_owned(),
-            client: Client::new(),
+            client,
             version,
         };
 


### PR DESCRIPTION
Increase the default timeout duration from 30 to 600 seconds.